### PR TITLE
Fixed bugs in array bounds. Added a test for array bounds (passes) an…

### DIFF
--- a/Test_3_1.py
+++ b/Test_3_1.py
@@ -1,32 +1,32 @@
-# import Kernel_Estimation_v6 as MonImage
-import Mes_Fonctions_v2 as MesFonctions
-from random import random
-import math
 import numpy as np
-import copy
 import opkpy_v3_1
 
+a = 1
+b = 100
 
-def rosenbrock(x):
-    return (x[0] - 1) * (x[0] - 1) + 10 * (x[0] * x[0] - x[1] * x[1]) * (x[0] * x[0] - x[1] * x[1])
+global_minimum = np.array([a, a ** 2])
 
+def rosen_fun(vec):
+    x, y = vec[0], vec[1]
+    return (a - x) ** 2 + b * (y - x ** 2) ** 2
 
+def rosen_grad(vec):
+    x, y = vec[0], vec[1]
+    df_dx = -2 * (a - 2 * b * x ** 3 + 2 * b * x * y - x)
+    df_dy = b * (2 * y - 2 * x ** 2)
+    return np.array([df_dx, df_dy]).astype('float32')
 
-def fg_rosen(x, gx):
-    gx[0] = 2 * (x[0] - 1) + 40 * x[0] * (x[0] * x[0] - x[1] * x[1])
-    gx[1] = -40 * x[1] * (x[0] * x[0] - x[1] * x[1])
-    return rosenbrock(x)
+def fg_rosen(vec):
+    return rosen_fun(vec), rosen_grad(vec)
 
 
 if __name__ == "__main__":
     opt = opkpy_v3_1.Optimizer()
-    bu= np.array([20, 10, 11, 12, 13], dtype="float32")
-    bl= np.array([0.2, 0.1, -0.1, 1.2, 1.3], dtype="float32")
-    x = np.array([-1.2, 1.0, 2.5, 3.6, 1.4], dtype="float32")
-    g = np.array([1, 2, 3 , 2 , 1], dtype="float32")
-    f = fg_rosen(x, g)
+    bu = np.array([20, 10], dtype="float32")
+    bl = np.array([0.2, 0.1], dtype="float32")
+    x = np.array([-1.2, 1.0], dtype="float32")
 
-    print("INPUT:" + str(x), str(x.dtype))
-    opt.minimize(x, fg_rosen, g, maxiter=5, maxeval=20, verbose=True)
-    print("OUTPUT:" + str(x))
+    found_minimum = opt.minimize(x, fg_rosen, bu=bu, bl=bl, maxiter=50, maxeval=50)
+    
+    assert(np.isclose(found_minimum, global_minimum, atol=1e-4).all())
 

--- a/opkpy_v3_1.py
+++ b/opkpy_v3_1.py
@@ -47,7 +47,7 @@ class Optimizer:
         self.iteration = 0
         self.evaluation = 0
 
-    def minimize(self, x, fg, g, bl=None, bu=None, algorithm="vmlmb", maxiter=500, maxeval=500, verbose=False):
+    def minimize(self, x, fg, bl=None, bu=None, algorithm="vmlmb", maxiter=500, maxeval=500, verbose=False):
         # Initialisation of the algorithm
 
         task = self.OPK_TASK_START
@@ -59,52 +59,61 @@ class Optimizer:
         # Beginning of the algorithm
         while True:
             if verbose:
-                print("task = ", self.OPK_TASKS[task])
+                print("PYTHON task = ", self.OPK_TASKS[task])
             if task == self.OPK_TASK_START:
                 task = opkc_v3_1.initialisation(x, algorithm, bu, bl)
-                # Caller must compute f(x) and g(x).
+            
+            # Caller must compute f(x) and g(x).
             elif task == self.OPK_TASK_COMPUTE_FG:
-                fx = fg(x, g)  # Compute f and g
+                fx, g = fg(x)  # Compute f and g
                 self.evaluation += 1  # Increase evaluation
                 task = opkc_v3_1.iterate(x, fx, g)  # Iterate
-                # A new iterate is available
+            
+            # A new iterate is available
             elif task == self.OPK_TASK_NEW_X:
                 self.iteration += 1  # Increase iteration
                 task = opkc_v3_1.iterate(x, fx, g)  # Iterate
-                # Algorithm has converged, solution is available
+            
+            # Algorithm has converged, solution is available
             elif task == self.OPK_TASK_FINAL_X:
                 print("Algorithm has converged, solution is available")
                 print("iteration = ", self.iteration, "     evaluation = ", self.evaluation)
                 break
-                # Algorithm terminated with a warning
+            
+            # Algorithm terminated with a warning
             elif task == self.OPK_TASK_WARNING:
                 print("Algorithm terminated with a warning")
                 error = True
-                # An error has ocurred
+            
+            # An error has ocurred
             elif task == self.OPK_TASK_ERROR:
                 print("ERROR OPK_TASK_ERROR has occurred, reason:", opkc_v3_1.get_reason())
                 error = True
-                # Error in the variable input
+            
+            # Error in the variable input
             else:
                 print("ERROR Unknown task has been asked:", task)
                 error = True
-                # An error has occured
+            # An error has occured
+            
             if error:
                 break
-                # Too much iterations, check OPK_TASK_NEW_X
+            
+            # Too much iterations, check OPK_TASK_NEW_X
             if self.iteration >= maxiter:
                 print("Too much iteration\n")
                 print("iteration = ", self.iteration, "     evaluation = ", self.evaluation)
                 break
-                # Too much evaluation of f and g, check OPK_TASK_COMPUTE_FG
+            
+            # Too much evaluation of f and g, check OPK_TASK_COMPUTE_FG
             if self.evaluation >= maxeval:
                 print("Too much evaluation\n")
                 print("iteration = ", self.iteration, "     evaluation = ", self.evaluation)
                 break
+            
             if fx and verbose:
-                print(" f(x) = ", fx)
+                print("PYTHON f(x) = ", fx)
         print("PY counter:", opkc_v3_1.counter," Single:", opkc_v3_1.single, opkc_v3_1.get_gnorm())
-        # self.close()
         return x
 
 
@@ -114,5 +123,3 @@ class Optimizer:
 
     def __del__(self):
         pass
-
-

--- a/test_quadratic.py
+++ b/test_quadratic.py
@@ -1,0 +1,21 @@
+import numpy as np
+import opkpy_v3_1
+
+
+target = np.array([5, 5, 5, 5, 5], dtype='float32')
+
+def fg(hypothesis):
+    global target
+    f = ((hypothesis - target) ** 2).sum()
+    gradient = 2 * (hypothesis - target)
+    return f, gradient
+
+bu= np.array([10, 10, 10, 10, 10], dtype="float32")
+bl= np.array([0, 0, 0, 0, 0], dtype="float32")
+x0 = np.array([7, 3, 5, 2, 3], dtype="float32")
+
+
+opt = opkpy_v3_1.Optimizer()
+solution = opt.minimize(x0, fg, bl=bl, bu=bu, maxiter=3, maxeval=3, verbose=False)
+
+assert((solution == target).all())

--- a/test_quadratic_scalar_bounds.py
+++ b/test_quadratic_scalar_bounds.py
@@ -1,0 +1,28 @@
+'''
+This test case is meant to check the support for scalar bounds (as opposed to arrays of values)
+It currently does not pass and I don't see how to make it work, because it is unclear how
+to pass the information about the bounds being non-array to the
+>opk_new_optimizer(algorithm_method, NULL, type, n,
+>                  bound_low, bound_low_arr,
+>                  bound_up, bound_up_arr, NULL);
+API defined in driver.c
+'''
+import numpy as np
+import opkpy_v3_1
+
+
+target = np.array([5, 5, 5, 5, 5], dtype='float32')
+
+def fg(hypothesis):
+    global target
+    f = ((hypothesis - target) ** 2).sum()
+    gradient = 2 * (hypothesis - target)
+    return f, gradient
+
+x0 = np.array([7, 3, 5, 2, 3], dtype="float32")
+
+opt = opkpy_v3_1.Optimizer()
+solution = opt.minimize(x0, fg, bl=0, bu=10, maxiter=3, maxeval=3, verbose=False)
+
+print(solution)
+assert((solution == target).all())


### PR DESCRIPTION
This fork includes things that I needed to fix in order to get the wrapper to work
* Fix float/double confusion in ``if (single == OPK_DOUBLE)``: single is already a boolean flag, comparing it is an error
* Fix using ``bound_up_obj`` for ``bound_low_arr_tmp``

Quality of life:
* More pythonic callback format, where it returns a tuple ``(function_value, gradient)`` instead of taking the gradient by a reference and modifying it that way (if I understood the intent correctly)

Aside from that I reworked the tests a bit, so that they actually assert things
* Test_3_1.py, the original Rosenbrock function test only uses 2 values, which are relevant (previously it was taking 5, but only using 2 of them) and now asserts the correct result
* Added another test on a quadratic function, with 5 parameters
* Emphasized a bug that disallows passing scalar bounds that would be "broadcast" to the full size. Despite the API accepting ``bl=0, bu=10``, this causes garbage memory accesses and doesn't work. I point out in comments where this happens, but I don't know how to easily fix it